### PR TITLE
Change version to 1.2.0 EDGDEMATIC-29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-dematic</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>


### PR DESCRIPTION
Snapshot version needs to be higher than last release in order for hosted reference environments to build.

More details can be found in [FOLIO-3209](https://issues.folio.org/browse/FOLIO-3209)