### PR TITLE
FOLIO-3370 set pom to next dev iteration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-dematic</artifactId>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>1.3.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>


### PR DESCRIPTION
SNAPSHOT version in the POM needs to be higher than the last released version (v1.3.1) on master/main. Setting to 1.3.2-SNAPSHOT.
https://dev.folio.org/guidelines/release-procedures/#maven-based-modules
