### PR TITLE
FOLIO-3370 - refenv builds fail, some modules have incorrect snapshot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-dematic</artifactId>
-  <version>1.3.2-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>


### PR DESCRIPTION
Upgrading snapshot version to prevent build failure

