### PR TITLE
EDGDEMATIC-70: edge-common 4.4.1 fixing disabled SSL in Vert.x WebClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <openfeign.version>3.1.3</openfeign.version>
     <edge-dematic.yaml.file>src/main/resources/swagger.api/edge-dematic.yaml</edge-dematic.yaml.file>
     <sonar.exclusions>src/main/java/org/folio/ed/domain/**, src/main/java/org/folio/ed/client/AuthnClient.java, src/main/java/org/folio/ed/error/ErrorControllerImpl.java</sonar.exclusions>
-    <edge-common.version>4.3.0</edge-common.version>
+    <edge-common.version>4.4.1</edge-common.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Upgrade edge-common from 4.3.0 to 4.4.1.
This upgrades Vert.x from 4.3.1 to 4.3.3 fixing disabled SSL in WebClient:
https://github.com/vert-x3/wiki/wiki/4.3.2-Release-Notes#vertx-web