### PR TITLE
EDGDEMATIC-72: Release 1.6.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 ## 1.7.0 - Unreleased
 
+## 1.6.1 - Released
+This release includes bug fixes
+
+### Bug Fixes
+* [EDGDEMATIC-70](https://issues.folio.org/browse/EDGDEMATIC-70) - edge-common 4.4.1 fixing disabled SSL in Vert.x WebClient
+
+[Full Changelog](https://github.com/folio-org/edge-dematic/compare/v1.6.0...v1.6.1)
+
 ## 1.6.0 - Released
 This release includes minor improvements (libraries dependencies cleanup and update)
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-dematic</artifactId>
-  <version>1.6.1</version>
+  <version>1.7.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -382,7 +382,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v1.6.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-dematic</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.6.1</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -382,7 +382,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.6.1</tag>
   </scm>
 
 </project>


### PR DESCRIPTION
https://issues.folio.org/browse/EDGDEMATIC-72 Release 1.6.1
https://issues.folio.org/browse/EDGDEMATIC-70 edge-common 4.4.1 fixing disabled SSL in Vert.x WebClient