### PR TITLE
EDGDEMATIC-95: Spring Boot 3.1.6 fixing Denial of Service (DoS)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.6</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
https://issues.folio.org/browse/EDGDEMATIC-95

Upgrade Spring Boot from 3.1.4 to 3.1.6 fixing Denial of Service (DoS):
https://www.cve.org/CVERecord?id=CVE-2023-34055

The Spring Boot upgrade indirectly upgrades Netty from 4.1.97.Final to 4.1.101.Final fixing Denial of Service (DoS): 
https://nvd.nist.gov/vuln/detail/CVE-2023-44487

The Spring Boot upgrade indirectly upgrades tomcat-embed-core from 10.1.13 to 10.1.16 fixing Denial of Service (DoS), Improper Input Validation, and Incomplete Cleanup:
https://nvd.nist.gov/vuln/detail/CVE-2023-44487
https://www.cve.org/CVERecord?id=CVE-2023-46589
https://nvd.nist.gov/vuln/detail/CVE-2023-45648
https://nvd.nist.gov/vuln/detail/CVE-2023-42795

The Spring Boot upgrade indirectly upgrades spring-web from 6.0.12 to 6.0.14 fixing Denial of Service (DoS):
https://www.cve.org/CVERecord?id=CVE-2023-34053