### PR TITLE
Replace BouncyCastle dependencies with Folio TLS Utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,26 +44,14 @@
     <!--Sonar properties-->
     <sonar.exclusions>src/main/java/org/folio/ed/domain/**, src/main/java/org/folio/ed/EdgeDematicApplication.java, src/main/java/org/folio/ed/error/ErrorControllerImpl.java</sonar.exclusions>
     <sonar.coverage.exclusions>src/main/java/org/folio/ed/util/MessageTypes.java</sonar.coverage.exclusions>
-    <bc-fips.version>1.0.2.5</bc-fips.version>
-    <bcpkix-fips.version>1.0.7</bcpkix-fips.version>
-    <bctls-fips.version>1.0.19</bctls-fips.version>
+    <folio-tls-utils.version>1.5.0</folio-tls-utils.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bc-fips</artifactId>
-      <version>${bc-fips.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-fips</artifactId>
-      <version>${bcpkix-fips.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bctls-fips</artifactId>
-      <version>${bctls-fips.version}</version>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-tls-utils</artifactId>
+      <version>${folio-tls-utils.version}</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/src/main/java/org/folio/ed/EdgeDematicApplication.java
+++ b/src/main/java/org/folio/ed/EdgeDematicApplication.java
@@ -1,7 +1,7 @@
 package org.folio.ed;
 
 
-import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -12,9 +12,7 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableAsync;
 
-import java.security.Security;
-
-import static org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider.PROVIDER_NAME;
+import static org.folio.common.utils.tls.FipsChecker.getFipsChecksResultString;
 
 @SpringBootApplication
 @EnableAsync
@@ -22,11 +20,10 @@ import static org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider.PROVIDER
 @EnableCaching
 @EnableAutoConfiguration(exclude = { DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class,
     HibernateJpaAutoConfiguration.class })
+@Log4j2
 public class EdgeDematicApplication {
   public static void main(String[] args) {
-    if (Security.getProvider(PROVIDER_NAME) == null) {
-      Security.addProvider(new BouncyCastleFipsProvider());
-    }
+    log.info(getFipsChecksResultString());
     SpringApplication.run(EdgeDematicApplication.class, args);
   }
 }


### PR DESCRIPTION
The BouncyCastle dependencies have been removed from the project's POM file and replaced with the Folio TLS Utils dependency.

