### PR TITLE
EDGDEMATIC-104: folio-spring-base 8.1.2,Spring 3.2.6,edge-common 4.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.2.6</version>
     <relativePath />
   </parent>
 
@@ -24,8 +24,8 @@
   <properties>
     <!--Dependencies properties-->
     <java.version>17</java.version>
-    <folio-spring-base.version>8.1.0</folio-spring-base.version>
-    <edge-common.version>4.6.0</edge-common.version>
+    <folio-spring-base.version>8.1.2</folio-spring-base.version>
+    <edge-common.version>4.7.0</edge-common.version>
     <spring-cloud-starter-bootstrap.version>4.1.1</spring-cloud-starter-bootstrap.version>
     <openapi-generator.version>7.3.0</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGDEMATIC-104

Upgrade folio-spring-base from 8.1.0 to 8.1.2.

Upgrade Spring Boot from 3.2.3 to 3.2.6.

Upgrade edge-common from 4.6.0 to 4.7.0.

The folio-spring-base upgrade indirectly upgrades bcprov-jdk18on from 1.74 to 1.78 fixing multiple vulnerabilities:

* https://www.cve.org/CVERecord?id=CVE-2024-30172  Ed25519 Infinitive Loop
* https://www.cve.org/CVERecord?id=CVE-2024-30171  RSA side-channel attack
* https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6277381  PKCS#1 1.5 and OAEP side-channel attack
* https://www.cve.org/CVERecord?id=CVE-2024-29857  ECCurve excessive CPU consumption

The bcprov-jdk18on vulnerabilities affect TLS:

* Both Ed25519 and RSA/*-RSA are used in TLSv1.2 and TLSv1.3: https://en.wikipedia.org/wiki/Transport_Layer_Security#Key_exchange_or_key_agreement
* ECCurve is a commonly used public key algorithm for certificates in TLSv1.2 and TLSv1.3. https://letsencrypt.org certbot uses it by default since version 2.0.0.

The Spring Boot upgrade indirectly upgrades spring-web from 6.1.4 to 6.1.8 fixing UriComponentsBuilder Open Redirect vulnerability: https://www.cve.org/CVERecord?id=CVE-2024-22259

The edge-common upgrade indirectly upgrades netty-codec-http from 4.1.107.Final to 4.1.110.Final fixing form POST OOM vulnerability: https://www.cve.org/CVERecord?id=CVE-2024-29025