### PR TITLE
EDGDEMATIC-109 - FOLIO needs to ignore messages with a null barcode and a status code of 000 

### DIFF
--- a/src/main/java/org/folio/ed/handler/StatusChannelHandler.java
+++ b/src/main/java/org/folio/ed/handler/StatusChannelHandler.java
@@ -26,7 +26,7 @@ public class StatusChannelHandler {
   public Object handle(String payload, Configuration configuration) {
     LOGGER.info("Status channel handler income: \"{}\"", payload);
     var tenantId = configuration.getTenantId();
-    if (resolveMessageType(payload) == INVENTORY_CONFIRM) {
+    if (resolveMessageType(payload) == INVENTORY_CONFIRM && !extractBarcode(payload).isEmpty()) {
       remoteStorageService.setAccessionedAsync(extractBarcode(payload), tenantId,
         sms.getStagingDirectorConnectionParameters(tenantId)
           .getOkapiToken().accessToken());

--- a/src/test/java/org/folio/ed/integration/StagingDirectorIntegrationTest.java
+++ b/src/test/java/org/folio/ed/integration/StagingDirectorIntegrationTest.java
@@ -137,6 +137,28 @@ public class StagingDirectorIntegrationTest extends TestBase {
     assertThat(setAccessionEvent.getResponse().getStatus(), is(204));
   }
 
+  @Test
+  void shouldRetunSuccessTrWhenInventoryConfirmHasNoBarcode() {
+    log.info("===== Receive successful Inventory Confirm (IC) and set accessioned by barcode : successful =====");
+    setMessage("IC0001520240802081209              000");
+    Configuration configuration = buildConfiguration();
+
+    integrationService.registerFeedbackChannelListener(configuration);
+    integrationService.registerStatusChannelFlow(configuration);
+
+    await().atMost(1, SECONDS).untilAsserted(() ->
+      verify(serverMessageHandler).handle(matches(TRANSACTION_RESPONSE_PATTERN), any()));
+
+    Map<String, ServeEvent> serveEvents = wireMockServer.getAllServeEvents()
+      .stream()
+      .collect(Collectors.toMap(e -> e.getRequest()
+        .getUrl(), identity()));
+//
+//    ServeEvent setAccessionEvent = serveEvents.get("/remote-storage/accessions/barcode/697685458679");
+//    assertThat(setAccessionEvent.getResponse().getStatus(), is(204));
+  }
+
+
   @ParameterizedTest
   @EnumSource(value = StagingDirectorErrorCodes.class, names = { "SUCCESS", "INVALID_SKU_FORMAT", "SKU_ALREADY_IN_DATABASE" })
   void shouldSetAccessionedByBarcodeOnInventoryConfirmWithAnyCode(StagingDirectorErrorCodes errorCode) {

--- a/src/test/java/org/folio/ed/integration/StagingDirectorIntegrationTest.java
+++ b/src/test/java/org/folio/ed/integration/StagingDirectorIntegrationTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
@@ -153,9 +154,9 @@ public class StagingDirectorIntegrationTest extends TestBase {
       .stream()
       .collect(Collectors.toMap(e -> e.getRequest()
         .getUrl(), identity()));
-//
-//    ServeEvent setAccessionEvent = serveEvents.get("/remote-storage/accessions/barcode/697685458679");
-//    assertThat(setAccessionEvent.getResponse().getStatus(), is(204));
+    //No server event for accessions as the item's barcode is not present in the IC message.
+    assertNull(serveEvents.get("/remote-storage/accessions/barcode/697685458679"));
+
   }
 
 


### PR DESCRIPTION
<!--
   If you have a relevant JIRA issue number, please put it in the issue title.
   Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

   TL;DR
     - https://www.youtube.com/watch?v=5aHmO_S8FQ4
     - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
     - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
 -->

## Purpose
To fix the issue reported in EDGDEMATIC-109
 <!--
   Why are you making this change? There is nothing more important
   to provide to the reviewer and to future readers than the cause
   that gave rise to this pull request. Be careful to avoid circular
   statements like "the purpose is to update the schema." and
   instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
   which is currently missing in the schema"

   The purpose may seem self-evident to you now, but the standard to
   hold yourself to should be "can a developer parachuting into this
   project reconstruct the necessary context merely by reading this
   section."

   If you have a relevant JIRA issue, add a link directly to the issue URL here.
   Example: https://issues.folio.org/browse/MODQM-3
  -->

## Approach
The approach taken is to scan the IC meesage payload for empty barcode string and not act upon instead return TR message as the ack as described in the jira.
 <!--
  How does this change fulfill the purpose? It's best to talk
  high-level strategy and avoid code-splaining the commit history.

  The goal is not only to explain what you did, but help other
  developers *work* with your solution in the future.
 -->

### TODOS and Open Questions
 <!-- OPTIONAL
 - [ ] Use GitHub checklists. When solved, check the box and explain the answer.
 -->

## Learning
 <!-- OPTIONAL
   Help out not only your reviewer, but also your fellow developer!
   Sometimes there are key pieces of information that you used to come up
   with your solution. Don't let all that hard work go to waste! A
   pull request is a *perfect opportunity to share the learning that
   you did. Add links to blog posts, patterns, libraries or addons used
   to solve this problem.
 -->

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [ ] Code coverage on new code is 80% or greater
   - [ ] Duplications on new code is 3% or less
   - [ ] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [ ] There are no breaking changes in this PR.
   - [ ] Check logging

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
