### PR TITLE
FOLIO-4229: Update edge-dematic from Java 17 to Java 21

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Only the fat jar file is needed for the Docker container
+*
+!target/*.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM folioci/alpine-jre-openjdk17:latest
+# https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk21
+FROM folioci/alpine-jre-openjdk21:latest
 
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
 USER root
+RUN apk upgrade --no-cache
+USER folio
 
-# Copy your fat jar to the container
-ENV APP_FILE edge-dematic-fat.jar
-
-# - should be a single jar file
-ARG JAR_FILE=./target/*.jar
-# - copy
-COPY ${JAR_FILE} ${JAVA_APP_DIR}/${APP_FILE}
+# Copy your fat jar to the container; if multiple *.jar files exist the .dockerignore file excludes others
+COPY target/*.jar ${JAVA_APP_DIR}
 
 # Expose this port locally in the container.
 EXPOSE 8081

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildMvn {
   publishModDescriptor = true
   mvnDeploy = true
-  buildNode = 'jenkins-agent-java17'
+  buildNode = 'jenkins-agent-java21'
 
   doDocker = {
     buildDocker {

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <!--Dependencies properties-->
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <folio-spring-base.version>8.2.1</folio-spring-base.version>
     <edge-common.version>4.7.0</edge-common.version>
     <spring-cloud-starter-bootstrap.version>4.1.1</spring-cloud-starter-bootstrap.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4229

## Purpose
Update edge-dematic from Java 17 to Java 21

## Approach
Follow
https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/393150471/Migration+to+Java+21+and+Spring+Boot+3.4
and
https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk21

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] There are no breaking changes in this PR.
   - [x] Check logging