### PR TITLE
EDGDEMATIC-143 - FOLIO not sending ACK to remote storage (dematic)

### DIFF
--- a/src/main/java/org/folio/ed/handler/StatusChannelHandler.java
+++ b/src/main/java/org/folio/ed/handler/StatusChannelHandler.java
@@ -30,7 +30,7 @@ public class StatusChannelHandler {
       remoteStorageService.setAccessionedAsync(extractBarcode(payload), tenantId,
         sms.getStagingDirectorConnectionParameters(tenantId)
           .getOkapiToken().accessToken());
-    } else if (resolveMessageType(payload) == ITEM_RETURNED) {
+    } else if (resolveMessageType(payload) == ITEM_RETURNED && !extractBarcode(payload).isEmpty()) {
       remoteStorageService.returnItemByBarcode(configuration.getId(), extractBarcode(payload), tenantId,
         sms.getStagingDirectorConnectionParameters(tenantId)
           .getOkapiToken().accessToken());

--- a/src/test/java/org/folio/ed/integration/StagingDirectorIntegrationTest.java
+++ b/src/test/java/org/folio/ed/integration/StagingDirectorIntegrationTest.java
@@ -312,6 +312,26 @@ public class StagingDirectorIntegrationTest extends TestBase {
       .getBodyAsString(), containsString("{\"itemBarcode\":\"697685458679\"}"));
   }
 
+  @Test
+  void shouldReturnSuccessTrWhenItemReturnedHasNoBarcode() {
+    log.info("===== Receive Item Returned (IR) with no barcode, send success TR and skip return : successful =====");
+    setMessage("IR0001520240802081209              000");
+    Configuration configuration = buildConfiguration();
+
+    integrationService.registerFeedbackChannelListener(configuration);
+    integrationService.registerStatusChannelFlow(configuration);
+
+    await().atMost(1, SECONDS).untilAsserted(() ->
+      verify(serverMessageHandler).handle(matches(TRANSACTION_RESPONSE_PATTERN), any()));
+
+    Map<String, ServeEvent> serveEvents = wireMockServer.getAllServeEvents()
+      .stream()
+      .collect(Collectors.toMap(e -> e.getRequest()
+        .getUrl(), identity()));
+    // No return call should happen since the IR message has no barcode.
+    assertNull(serveEvents.get("/remote-storage/return/de17bad7-2a30-4f1c-bee5-f653ded15629"));
+  }
+
   private Configuration buildConfiguration() {
     Configuration configuration = new Configuration();
     configuration.setId("de17bad7-2a30-4f1c-bee5-f653ded15629");

--- a/src/test/java/org/folio/ed/integration/StagingDirectorIntegrationTest.java
+++ b/src/test/java/org/folio/ed/integration/StagingDirectorIntegrationTest.java
@@ -2,6 +2,8 @@ package org.folio.ed.integration;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.function.Function.identity;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.awaitility.Awaitility.await;
 import static org.folio.ed.security.DematicSecurityManagerServiceTest.OKAPI_TOKEN;
 import static org.folio.ed.support.ServerMessageHelper.setMessage;
@@ -324,12 +326,7 @@ public class StagingDirectorIntegrationTest extends TestBase {
     await().atMost(1, SECONDS).untilAsserted(() ->
       verify(serverMessageHandler).handle(matches(TRANSACTION_RESPONSE_PATTERN), any()));
 
-    Map<String, ServeEvent> serveEvents = wireMockServer.getAllServeEvents()
-      .stream()
-      .collect(Collectors.toMap(e -> e.getRequest()
-        .getUrl(), identity()));
-    // No return call should happen since the IR message has no barcode.
-    assertNull(serveEvents.get("/remote-storage/return/de17bad7-2a30-4f1c-bee5-f653ded15629"));
+    wireMockServer.verify(0, putRequestedFor(urlPathMatching("/remote-storage/return/.*")));
   }
 
   private Configuration buildConfiguration() {


### PR DESCRIPTION
[EDGDEMATIC-143](https://folio-org.atlassian.net/browse/EDGDEMATIC-143) - FOLIO not sending ACK to remote storage (dematic)

### Purpose
When Dematic sends an ItemReturned message with no barcode, edge-dematic still calls mod-remote-storage's return endpoint with an empty barcode. That call fails with a 400, and since the RestClient throws on 4xx, the handler never builds the success transaction response - so no ACK (000) is returned. Dematic then keeps re-sending the same message (per vendor behaviour), causing a loop. 

### Approach
In StatusChannelHandler, the ITEM_RETURNED branch now skips the returnItemByBarcode call when the extracted barcode is empty (&& !extractBarcode(payload).isEmpty()), mirroring the existing INVENTORY_CONFIRM guard. The success transaction response (TR 000) is still built and returned, so the message is acknowledged and ignored. Only the empty-barcode case is affected; messages with a real barcode are unchanged. 

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[EDGDEMATIC-XXX](https://folio-org.atlassian.net/browse/EDGDEMATIC-XXX)
_List any Jira issues related to this pull request._

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
