### PR TITLE
EDGDEMATIC-92 - Need readiness health check endpoint for this module

### DIFF
--- a/src/main/java/org/folio/ed/controller/ReadinessController.java
+++ b/src/main/java/org/folio/ed/controller/ReadinessController.java
@@ -1,0 +1,25 @@
+package org.folio.ed.controller;
+
+import org.folio.ed.service.StagingDirectorIntegrationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ReadinessController {
+
+  private final StagingDirectorIntegrationService stagingDirectorIntegrationService;
+
+  @GetMapping("/admin/ready")
+  public ResponseEntity<String> checkReadiness() {
+    if (stagingDirectorIntegrationService.isReady()) {
+      return ResponseEntity.ok("READY");
+    } else {
+      return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("NOT READY");
+    }
+  }
+}

--- a/src/main/java/org/folio/ed/security/EdgeSecurityFilter.java
+++ b/src/main/java/org/folio/ed/security/EdgeSecurityFilter.java
@@ -27,6 +27,7 @@ public class EdgeSecurityFilter implements Filter {
 
   public static final String HEALTH_ENDPOINT = "/admin/health";
   public static final String INFO_ENDPOINT = "/admin/info";
+  public static final String READY_ENDPOINT = "/admin/ready";
 
   private final SecurityManagerService sms;
   private final ApiKeyHelper apiKeyHelper;
@@ -67,6 +68,6 @@ public class EdgeSecurityFilter implements Filter {
   }
 
   private boolean isAuthorizationNeeded(String path) {
-    return !(path.contains(HEALTH_ENDPOINT) || path.equals(INFO_ENDPOINT));
+    return !(path.contains(HEALTH_ENDPOINT) || path.equals(INFO_ENDPOINT) || path.equals(READY_ENDPOINT));
   }
 }

--- a/src/main/java/org/folio/ed/service/StagingDirectorIntegrationService.java
+++ b/src/main/java/org/folio/ed/service/StagingDirectorIntegrationService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 
 import jakarta.annotation.PostConstruct;
 import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +43,8 @@ public class StagingDirectorIntegrationService {
 
   @Value("${primary.channel.heartbeat.timeframe}")
   private long heartbeatTimeframe;
+
+  private static final AtomicBoolean isReady = new AtomicBoolean(false);
 
   private final IntegrationFlowContext integrationFlowContext;
   private final RemoteStorageService remoteStorageService;
@@ -62,10 +65,16 @@ public class StagingDirectorIntegrationService {
           createFlows(configuration);
         }
       }
+      isReady.set(true);
     }
     catch( Exception ex) {
       log.error("createIntegrationFlows:: exception : {}, message : {}", ex, ex.getMessage());
+      isReady.set(false);
     }
+  }
+
+  public boolean isReady() {
+    return isReady.get();
   }
 
   private void createFlows(Configuration configuration) {

--- a/src/test/java/org/folio/ed/controller/ReadinessControllerTest.java
+++ b/src/test/java/org/folio/ed/controller/ReadinessControllerTest.java
@@ -1,0 +1,43 @@
+package org.folio.ed.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.folio.ed.service.StagingDirectorIntegrationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class ReadinessControllerTest {
+
+  @Mock
+  private StagingDirectorIntegrationService stagingDirectorIntegrationService;
+
+  @InjectMocks
+  private ReadinessController readinessController;
+
+  @Test
+  void testReadinessControllerReady() {
+    when(stagingDirectorIntegrationService.isReady()).thenReturn(true);
+    
+    ResponseEntity<String> response = readinessController.checkReadiness();
+    
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("READY", response.getBody());
+  }
+
+  @Test
+  void testReadinessControllerNotReady() {
+    when(stagingDirectorIntegrationService.isReady()).thenReturn(false);
+    
+    ResponseEntity<String> response = readinessController.checkReadiness();
+    
+    assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+    assertEquals("NOT READY", response.getBody());
+  }
+}

--- a/src/test/java/org/folio/ed/security/EdgeSecurityFilterTest.java
+++ b/src/test/java/org/folio/ed/security/EdgeSecurityFilterTest.java
@@ -16,6 +16,7 @@ public class EdgeSecurityFilterTest extends TestBase {
 
   private static final String HEALTH_CHECK_ENDPOINT = "http://localhost:%s/admin/health";
   private static final String INFO_ENDPOINT = "http://localhost:%s/admin/info";
+  private static final String READY_ENDPOINT = "http://localhost:%s/admin/ready";
 
   @Test
   void testHealthCheck() {
@@ -32,5 +33,16 @@ public class EdgeSecurityFilterTest extends TestBase {
     var response = get(String.format(INFO_ENDPOINT, edgeDematicPort), getEmptyHeaders(), JsonNode.class);
     assertThat(response.getBody(), notNullValue());
     assertThat(response.getBody().isObject(), equalTo(true));
+  }
+
+  @Test
+  void testReady() {
+    log.info("===== Verify ready endpoint =====");
+    try {
+      var response = get(String.format(READY_ENDPOINT, edgeDematicPort), getEmptyHeaders(), String.class);
+      assertThat(response.getStatusCode().value(), org.hamcrest.Matchers.anyOf(equalTo(200), equalTo(503)));
+    } catch (org.springframework.web.client.HttpStatusCodeException e) {
+      assertThat(e.getStatusCode().value(), org.hamcrest.Matchers.anyOf(equalTo(200), equalTo(503)));
+    }
   }
 }

--- a/src/test/java/org/folio/ed/service/StagingDirectorIntegrationServiceTest.java
+++ b/src/test/java/org/folio/ed/service/StagingDirectorIntegrationServiceTest.java
@@ -35,6 +35,7 @@ public class StagingDirectorIntegrationServiceTest extends TestBase {
   void shouldGetConfigurationAndCreateIntegrationFlows() {
     await().atMost(1, TimeUnit.SECONDS).untilAsserted(() ->
       assertThat(integrationFlowContext.getRegistry().size(), is(6)));
+    assertEquals(true, integrationService.isReady());
   }
 
   @Test
@@ -53,6 +54,7 @@ public class StagingDirectorIntegrationServiceTest extends TestBase {
     verify(sms,times(1)).getStagingDirectorTenantsUsers();
     var res = verify(sms).getStagingDirectorTenantsUsers();
     assertEquals(null,res);
+    assertEquals(false, stagingDirectorIntegrationService.isReady());
   }
 
 


### PR DESCRIPTION
### Purpose
This PR introduces a dedicated readiness health check endpoint (`/admin/ready`) for the `edge-dematic` module. 
The new `/admin/ready` endpoint solves this by reflecting the actual functional readiness of the module's internal mechanisms.

### Approach
- **State Tracking:** Introduced an `isReady` property in `StagingDirectorIntegrationService`. The state is set to `true` only if the module successfully fetches configuration from `mod-remote-storage` and completes the registration of its Spring Integration flows during `@PostConstruct`.
- **New Endpoint:** Created `ReadinessController` to expose `GET /admin/ready`. It returns `200 OK` ("READY") if the service is fully initialized, and `503 Service Unavailable` ("NOT READY") if it failed to establish the integration flows.
- **Security:** Updated `EdgeSecurityFilter` to add `/admin/ready` to the list of unprotected endpoints alongside `/admin/health` and `/admin/info`, allowing orchestration and monitoring tools to ping it without an API key.
- **Testing:** Implemented `ReadinessControllerTest` using Mockito to verify the HTTP responses based on the service's readiness state.

### Changes Checklist
- [x] **API Changes**: Added unprotected endpoint `GET /admin/ready` (Returns `200 OK` or `503 Service Unavailable`).
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests (`ReadinessControllerTest`).
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[EDGDEMATIC-92](https://folio-org.atlassian.net/browse/EDGDEMATIC-92)

### Learning and Resources (if applicable)
Adhered to the FOLIO Technical Council Decision Record ([DR-000007](https://folio-org.atlassian.net/wiki/display/TC/DR-000007+-+Back+End+Module+Health+Check+Protocol)), which dictates that `/admin/health` must remain strictly a liveness probe to prevent cascading Kubernetes restarts when dependencies are temporarily down.
